### PR TITLE
Disable `chainlit` automatic scroll to message

### DIFF
--- a/frontend/chat/.chainlit/config.toml
+++ b/frontend/chat/.chainlit/config.toml
@@ -30,6 +30,9 @@ auto_tag_thread = true
 # Allow users to edit their own messages.
 edit_message = false
 
+# Autoscroll new user messages at the top of the window
+user_message_autoscroll = false
+
 # Authorize users to spontaneously upload files with messages.
 [features.spontaneous_file_upload]
     enabled = false


### PR DESCRIPTION
See this issue in the `chainlit` repository (i.e., https://github.com/Chainlit/chainlit/issues/1992).